### PR TITLE
Update ESP_MQTT_Digital_LEDs.ino

### DIFF
--- a/ESP_MQTT_Digital_LEDs/ESP_MQTT_Digital_LEDs.ino
+++ b/ESP_MQTT_Digital_LEDs/ESP_MQTT_Digital_LEDs.ino
@@ -10,6 +10,7 @@ This is the code I use for my MQTT LED Strip controlled from Home Assistant. It'
 
 */
 
+#define FASTLED_ALLOW_INTERRUPTS 0 // Helps prevent glitches in longer strips, especially with faster effects (Sinelon, Glitter...)
 
 #include <ESP8266WiFi.h>
 #include <PubSubClient.h>


### PR DESCRIPTION
In longer WS2811 strips (50+ LEDs), glitches occur due to interrupts. Disabling interrupts allows much smoother, glitch-free animations.